### PR TITLE
[fix] allow download from URLs without filename

### DIFF
--- a/metagoofil.py
+++ b/metagoofil.py
@@ -57,7 +57,11 @@ class DownloadWorker(threading.Thread):
                     print("[+] Downloading file - [{0} bytes] {1}".format(size, url))
 
                     # Extract file name.
-                    filename = str(url.split("/")[-1])
+                    url_parts = url.split("/")
+                    filename = str(url_parts[-1])
+
+                    if not filename:
+                        filename = str(url_parts[-2])
 
                     with open(os.path.join(mg.save_directory, filename), "wb") as fh:
                         for chunk in response.iter_content(chunk_size=1024):


### PR DESCRIPTION
There was a bug that does not allow the automatic download of files when the URL does not finish with a filename, such as:

https://example.com/download/file/3913/

Now, if this is the case, the file is named as the last part of the URL (in this case, "3913").