### PR TITLE
fix halting due to wrong file name or url

### DIFF
--- a/metagoofil.py
+++ b/metagoofil.py
@@ -76,6 +76,8 @@ class DownloadWorker(threading.Thread):
 
             except requests.exceptions.RequestException as e:
                 print(f"[-] Exception for url: {url} -- {e}")
+            except OSError as e:
+                print(f"[-] Download error: {e}")
 
             mg.queue.task_done()
 


### PR DESCRIPTION
Sometimes threads drop with exception and halt due to wrong urls:

[Errno 22] Invalid argument: 'folder\\file.php?id=5394'

or incorrect filenames for OS:

[Errno 2] No such file or directory: 'folder\\%D0%93%D1%80%D0%B0%D0%B6%D0%B4%D0%B0%D0%BD%D1%81%D1%82%D0%B2%D0%BE_%D0%B4%D0%BB%D1%8F_%D0%B8%D0%BD%D0%BE%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%BD%D1%8B%D1%85_%D1%81%D1%82%D1%83%D0%B4%D0%B5%D0%BD%D1%82%D0%BE%D0%B2_%D0%B3%D0%BE%D1%81%D1%83%D0%B4%D0%B0%D1%80%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D1%8B%D1%85_%D0%92%D0%A3%D0%97%D0%BE%D0%B2.docx